### PR TITLE
fix: boost::shared_ptr to std::shared_ptr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /CMakeLists.txt
 .catkin_tools/
+.idea/

--- a/ensenso_camera/package.xml
+++ b/ensenso_camera/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>roslint</build_depend>
+  <depend>ensenso_sdk</depend>
   <depend>actionlib</depend>
   <depend>cv_bridge</depend>
   <depend>diagnostic_msgs</depend>

--- a/ensenso_camera/src/point_cloud_utilities.cpp
+++ b/ensenso_camera/src/point_cloud_utilities.cpp
@@ -18,7 +18,7 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr pointCloudFromNxLib(NxLibItem const& node, s
   node.getBinaryDataInfo(&width, &height, 0, 0, 0, &timestamp);
   node.getBinaryData(data, 0);
 
-  auto cloud = boost::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+  auto cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
 
   // PCL timestamp is in microseconds and Unix time.
   cloud->header.stamp = ensenso_conversion::nxLibToPclTimestamp(timestamp);
@@ -59,7 +59,7 @@ pcl::PointCloud<pcl::PointNormal>::Ptr pointCloudWithNormalsFromNxLib(NxLibItem 
   pointMapNode.getBinaryData(pointData, 0);
   normalNode.getBinaryData(normalData, 0);
 
-  auto cloud = boost::make_shared<pcl::PointCloud<pcl::PointNormal>>();
+  auto cloud = std::make_shared<pcl::PointCloud<pcl::PointNormal>>();
 
   // PCL timestamp is in microseconds and Unix time.
   cloud->header.stamp = ensenso_conversion::nxLibToPclTimestamp(timestamp);
@@ -105,7 +105,7 @@ pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloudTexturedFromNxLib(NxLibItem con
   pointsNode.getBinaryData(data, &timestamp);
   imageNode.getBinaryData(imageData, 0);
 
-  auto cloud_colored = boost::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
+  auto cloud_colored = std::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
 
   // PCL timestamp is in microseconds and Unix time.
   cloud_colored->header.stamp = ensenso_conversion::nxLibToPclTimestamp(timestamp);

--- a/ensenso_camera/src/stereo_camera.cpp
+++ b/ensenso_camera/src/stereo_camera.cpp
@@ -426,7 +426,7 @@ void StereoCamera::onRequestData(ensenso_camera_msgs::RequestDataGoalConstPtr co
       }
       if (publishResults)
       {
-        pointCloudPublisher.publish(pointCloud);
+        pointCloudPublisher.publish(*pointCloud);
       }
     }
     else
@@ -443,7 +443,7 @@ void StereoCamera::onRequestData(ensenso_camera_msgs::RequestDataGoalConstPtr co
       }
       if (publishResults)
       {
-        pointCloudPublisher.publish(pointCloud);
+        pointCloudPublisher.publish(*pointCloud);
       }
     }
   }
@@ -1164,7 +1164,7 @@ void StereoCamera::onTexturedPointCloud(ensenso_camera_msgs::TexturedPointCloudG
     auto cloudColored = retrieveTexturedPointCloud(renderPointMap.result(), params.targetFrame);
     if (goal->publish_results)
     {
-      pointCloudPublisherColor.publish(cloudColored);
+      pointCloudPublisherColor.publish(*cloudColored);
     }
     if (goal->include_results_in_response)
     {

--- a/ensenso_camera/src/texture_point_cloud.cpp
+++ b/ensenso_camera/src/texture_point_cloud.cpp
@@ -19,7 +19,7 @@ using TexturedPointCloud = pcl::PointCloud<pcl::PointXYZRGB>;
 TexturedPointCloud::Ptr texturePointCloudFromRectifiedImage(cv::Mat const& image,
                                                             PointCloud::ConstPtr const& pointCloud)
 {
-  auto texturedPointCloud = boost::make_shared<TexturedPointCloud>();
+  auto texturedPointCloud = std::make_shared<TexturedPointCloud>();
 
   if (static_cast<int>(pointCloud->width) != image.cols || static_cast<int>(pointCloud->height) != image.rows)
   {
@@ -98,11 +98,11 @@ private:
     latestImage = image;
   }
 
-  void onPointCloudReceived(PointCloud::ConstPtr const& pointCloud)
+  void onPointCloudReceived(boost::shared_ptr<const PointCloud> const& pointCloud)
   {
     std::lock_guard<std::mutex> lock(mutex);
 
-    latestPointCloud = pointCloud;
+    latestPointCloud = std::make_shared<const PointCloud>(*pointCloud);
     texture();
   }
 
@@ -124,7 +124,7 @@ private:
     TexturedPointCloud::Ptr texturedPointCloud;
     texturedPointCloud = texturePointCloudFromRectifiedImage(image->image, latestPointCloud);
 
-    texturedPointCloudPublisher.publish(texturedPointCloud);
+    texturedPointCloudPublisher.publish(*texturedPointCloud);
   }
 };
 

--- a/ensenso_camera_msgs/package.xml
+++ b/ensenso_camera_msgs/package.xml
@@ -20,6 +20,7 @@
   <build_export_depend>message_runtime</build_export_depend>
   <exec_depend>message_runtime</exec_depend>
 
+  <depend>ensenso_sdk</depend>
   <depend>actionlib_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
* Some boost::shared_ptr instances were migrated to std::shared_ptr for compatibility with PCL APIs.
* Some publish method arguments were pointers and needed to be contents of the pointers.
* Added implicit dependency to ensenso_sdk in package.xml file (camera).